### PR TITLE
Fix move switching in the summary screen

### DIFF
--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -2833,9 +2833,7 @@ void Task_SwitchPageInMoveSelect(u8 taskId)
             data[0]++;
             break;
         case 4:
-            if (sMonSummaryScreen->firstMoveIndex == MAX_MON_MOVES)
-                PrintMoveDetails(sMonSummaryScreen->newMove);
-            else
+            if (sMonSummaryScreen->firstMoveIndex != MAX_MON_MOVES)
                 PrintMoveDetails(sMonSummaryScreen->summary.moves[sMonSummaryScreen->firstMoveIndex]);
             PutWindowTilemap(PSS_LABEL_PANE_LEFT_MOVE);
             data[0]++;


### PR DESCRIPTION
## Description
Ported fix from my summary screen branch made in collab with Citrus Bolt

This change fixes this bug:
![mGBA_jiBzUtBOVD](https://github.com/Elite-Redux/eliteredux/assets/18596778/0129266c-4990-4a11-8121-e74002d62d3a)

## **Discord contact info**
671gz