### PR TITLE
Optimize move learner dialog to improve menu scroll speed

### DIFF
--- a/gflib/window.c
+++ b/gflib/window.c
@@ -460,6 +460,12 @@ void FillWindowPixelBuffer(u8 windowId, u8 fillValue)
     CpuFastFill8(fillValue, gWindows[windowId].tileData, 32 * fillSize);
 }
 
+void CopyWindowToWindow(u8 from, u8 to)
+{
+    int fillSize = gWindows[from].window.width * gWindows[from].window.height;
+    CpuCopy32(gWindows[from].tileData, gWindows[to].tileData, 32 * fillSize);
+}
+
 #define MOVE_TILES_DOWN(a)                                                      \
 {                                                                               \
     destOffset = i + (a);                                                       \

--- a/gflib/window.h
+++ b/gflib/window.h
@@ -78,6 +78,7 @@ void FillWindowPixelBuffer8Bit(u8 windowId, u8 fillValue);
 void FillWindowPixelRect8Bit(u8 windowId, u8 fillValue, u16 x, u16 y, u16 width, u16 height);
 void BlitBitmapRectToWindow4BitTo8Bit(u8 windowId, const u8 *pixels, u16 srcX, u16 srcY, u16 srcWidth, int srcHeight, u16 destX, u16 destY, u16 rectWidth, u16 rectHeight, u8 paletteNum);
 void CopyWindowToVram8Bit(u8 windowId, u8 mode);
+void CopyWindowToWindow(u8 from, u8 to);
 
 extern struct Window gWindows[];
 extern void* gWindowBgTilemapBuffers[];

--- a/src/menu_specialized.c
+++ b/src/menu_specialized.c
@@ -25,6 +25,7 @@
 #include "window.h"
 #include "constants/songs.h"
 #include "gba/io_reg.h"
+#include "mgba_printf/mgba.h"
 
 extern const struct CompressedSpriteSheet gMonFrontPicTable[];
 
@@ -730,33 +731,39 @@ u8 LoadMoveRelearnerMovesList(const struct ListMenuItem *items, u16 numChoices)
     return gMultiuseListMenuTemplate.maxShowed;
 }
 
-static void MoveRelearnerLoadBattleMoveDescription(u32 chosenMove)
+static void MoveRelearnerLoadBattleMoveDescription(u32 chosenMove, bool8 onInit)
 {
     s32 x;
     const struct BattleMove *move;
     u8 buffer[0x20];
     const u8 *str;
 
-    FillWindowPixelBuffer(0, PIXEL_FILL(1));
-    str = gText_MoveRelearnerBattleMoves;
-    x = GetStringCenterAlignXOffset(1, str, 0x80);
-    AddTextPrinterParameterized(0, 1, str, x, 1, TEXT_SPEED_FF, NULL);
+    if (onInit) {
+        FillWindowPixelBuffer(1, PIXEL_FILL(1));
+        str = gText_MoveRelearnerBattleMoves;
+        x = GetStringCenterAlignXOffset(1, str, 0x80);
+        AddTextPrinterParameterized(1, 1, str, x, 1, TEXT_SPEED_FF, NULL);
 
-    str = gText_MoveRelearnerPP;
-    AddTextPrinterParameterized(0, 1, str, 4, 0x29, TEXT_SPEED_FF, NULL);
+        str = gText_MoveRelearnerPP;
+        AddTextPrinterParameterized(1, 1, str, 4, 0x29, TEXT_SPEED_FF, NULL);
 
-    str = gText_MoveRelearnerPower;
-    x = GetStringRightAlignXOffset(1, str, 0x6A);
-    AddTextPrinterParameterized(0, 1, str, x, 0x19, TEXT_SPEED_FF, NULL);
+        str = gText_MoveRelearnerPower;
+        x = GetStringRightAlignXOffset(1, str, 0x6A);
+        AddTextPrinterParameterized(1, 1, str, x, 0x19, TEXT_SPEED_FF, NULL);
 
-    str = gText_MoveRelearnerAccuracy;
-    x = GetStringRightAlignXOffset(1, str, 0x6A);
-    AddTextPrinterParameterized(0, 1, str, x, 0x29, TEXT_SPEED_FF, NULL);
+        str = gText_MoveRelearnerAccuracy;
+        x = GetStringRightAlignXOffset(1, str, 0x6A);
+        AddTextPrinterParameterized(1, 1, str, x, 0x29, 0, NULL);
+    }
+
+    CopyWindowToWindow(1, 0);
+
     if (chosenMove == LIST_CANCEL)
     {
         CopyWindowToVram(0, 2);
         return;
     }
+
     move = &gBattleMoves[chosenMove];
     str = gTypeNames[move->type];
     AddTextPrinterParameterized(0, 1, str, 4, 0x19, TEXT_SPEED_FF, NULL);
@@ -791,48 +798,11 @@ static void MoveRelearnerLoadBattleMoveDescription(u32 chosenMove)
     AddTextPrinterParameterized(0, 7, str, 0, 0x41, 0, NULL);
 }
 
-static void MoveRelearnerMenuLoadContestMoveDescription(u32 chosenMove)
-{
-    s32 x;
-    const u8 *str;
-    const struct ContestMove *move;
-
-    MoveRelearnerShowHideHearts(chosenMove);
-    FillWindowPixelBuffer(1, PIXEL_FILL(1));
-    str = gText_MoveRelearnerContestMovesTitle;
-    x = GetStringCenterAlignXOffset(1, str, 0x80);
-    AddTextPrinterParameterized(1, 1, str, x, 1, TEXT_SPEED_FF, NULL);
-
-    str = gText_MoveRelearnerAppeal;
-    x = GetStringRightAlignXOffset(1, str, 0x5C);
-    AddTextPrinterParameterized(1, 1, str, x, 0x19, TEXT_SPEED_FF, NULL);
-
-    str = gText_MoveRelearnerJam;
-    x = GetStringRightAlignXOffset(1, str, 0x5C);
-    AddTextPrinterParameterized(1, 1, str, x, 0x29, TEXT_SPEED_FF, NULL);
-
-    if (chosenMove == MENU_NOTHING_CHOSEN)
-    {
-        CopyWindowToVram(1, 2);
-        return;
-    }
-
-    move = &gContestMoves[chosenMove];
-    str = gContestMoveTypeTextPointers[move->contestCategory];
-    AddTextPrinterParameterized(1, 1, str, 4, 0x19, TEXT_SPEED_FF, NULL);
-
-    str = gContestEffectDescriptionPointers[move->effect];
-    AddTextPrinterParameterized(1, 7, str, 0, 0x41, TEXT_SPEED_FF, NULL);
-
-    CopyWindowToVram(1, 2);
-}
-
 static void MoveRelearnerCursorCallback(s32 itemIndex, bool8 onInit, struct ListMenu *list)
 {
     if (onInit != TRUE)
         PlaySE(SE_SELECT);
-    MoveRelearnerLoadBattleMoveDescription(itemIndex);
-    MoveRelearnerMenuLoadContestMoveDescription(itemIndex);
+    MoveRelearnerLoadBattleMoveDescription(itemIndex, onInit);
 }
 
 void MoveRelearnerPrintText(u8 *str)

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -798,28 +798,6 @@ static void HandleInput(bool8 showContest)
     switch (itemId)
     {
     case LIST_NOTHING_CHOSEN:
-        if (!(JOY_NEW(DPAD_LEFT | DPAD_RIGHT)) && !GetLRKeysPressed())
-        {
-            break;
-        }
-
-        PlaySE(SE_SELECT);
-
-        if (showContest == FALSE)
-        {
-            PutWindowTilemap(1);
-            sMoveRelearnerStruct->state = MENU_STATE_SETUP_CONTEST_MODE;
-            sMoveRelearnerMenuSate.showContestInfo = TRUE;
-        }
-        else
-        {
-            PutWindowTilemap(0);
-            sMoveRelearnerStruct->state = MENU_STATE_SETUP_BATTLE_MODE;
-            sMoveRelearnerMenuSate.showContestInfo = FALSE;
-        }
-
-        ScheduleBgCopyTilemapToVram(1);
-        MoveRelearnerShowHideHearts(GetCurrentSelectedMove());
         break;
     case LIST_CANCEL:
         PlaySE(SE_SELECT);
@@ -867,33 +845,14 @@ static void CreateUISprites(void)
     sMoveRelearnerStruct->moveDisplayArrowTask = TASK_NONE;
     sMoveRelearnerStruct->moveListScrollArrowTask = TASK_NONE;
     AddScrollArrows();
-
-    // These are the appeal hearts.
-    for (i = 0; i < 8; i++)
-    {
-        sMoveRelearnerStruct->heartSpriteIds[i] = CreateSprite(&sConstestMoveHeartSprite, (i - (i / 4) * 4) * 8 + 104, (i / 4) * 8 + 36, 0);
-    }
-
-    // These are the jam harts.
-    // The animation is used to toggle between full/empty heart sprites.
-    for (i = 0; i < 8; i++)
-    {
-        sMoveRelearnerStruct->heartSpriteIds[i + 8] = CreateSprite(&sConstestMoveHeartSprite, (i - (i / 4) * 4) * 8 + 104, (i / 4) * 8 + 52, 0);
-        StartSpriteAnim(&gSprites[sMoveRelearnerStruct->heartSpriteIds[i + 8]], 2);
-    }
-
-    for (i = 0; i < 16; i++)
-    {
-        gSprites[sMoveRelearnerStruct->heartSpriteIds[i]].invisible = TRUE;
-    }
 }
 
 static void AddScrollArrows(void)
 {
-    if (sMoveRelearnerStruct->moveDisplayArrowTask == TASK_NONE)
-    {
-        sMoveRelearnerStruct->moveDisplayArrowTask = AddScrollIndicatorArrowPair(&sDisplayModeArrowsTemplate, &sMoveRelearnerStruct->scrollOffset);
-    }
+    // if (sMoveRelearnerStruct->moveDisplayArrowTask == TASK_NONE)
+    // {
+    //     sMoveRelearnerStruct->moveDisplayArrowTask = AddScrollIndicatorArrowPair(&sDisplayModeArrowsTemplate, &sMoveRelearnerStruct->scrollOffset);
+    // }
 
     if (sMoveRelearnerStruct->moveListScrollArrowTask == TASK_NONE)
     {


### PR DESCRIPTION
Removes rendering of unneeded and obscured contest information data and caches static window elements to improve rendering of the move relearner window by ~9 frames, for an increase in scroll speed when tapping of ~113% (17 -> 8) and an increase in scroll speed when holding by ~69% (22 -> 13). Potential followups are to allow left/right arrows to swap between move types (level, tm, tutor, egg) and to add move type to the window title.