### PR TITLE
Fix Wattson's New Mauville flags in case they got borked

### DIFF
--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -706,16 +706,6 @@ static void Task_MainMenuCheckSaveFile(u8 taskId)
     s16* data = gTasks[taskId].data;
 	u16 timesUpdated = 0 + VarGet(VAR_UPDATED_TIMES);
 
-    if(VarGet(VAR_SAVE_VERSION) < 1017){
-        //updating version
-        FlagClear(FLAG_GOT_TM24_FROM_WATTSON);
-        if(FlagGet(FLAG_BADGE05_GET) == TRUE){
-            FlagSet(FLAG_GOT_TM24_FROM_WATTSON);
-            FlagClear(FLAG_HIDE_MAUVILLE_CITY_WATTSON);
-            FlagClear(FLAG_WATTSON_REMATCH_AVAILABLE);
-        }
-    }
-
     if(VarGet(VAR_SAVE_VERSION) <= 1033){
         if(FlagGet(FLAG_GOT_TM24_FROM_WATTSON) && VarGet(VAR_NEW_MAUVILLE_STATE) != 6) {
             FlagClear(FLAG_GOT_TM24_FROM_WATTSON);

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -716,6 +716,18 @@ static void Task_MainMenuCheckSaveFile(u8 taskId)
         }
     }
 
+    if(VarGet(VAR_SAVE_VERSION) <= 1033){
+        if(FlagGet(FLAG_GOT_TM24_FROM_WATTSON) && VarGet(VAR_NEW_MAUVILLE_STATE) != 6) {
+            FlagClear(FLAG_GOT_TM24_FROM_WATTSON);
+        }
+
+        if(!FlagGet(FLAG_GOT_TM24_FROM_WATTSON) && FlagGet(FLAG_BADGE05_GET) && FlagGet(FLAG_HIDE_MAUVILLE_CITY_WATTSON)) {
+            FlagClear(FLAG_HIDE_MAUVILLE_CITY_WATTSON);
+            FlagSet(FLAG_HIDE_MAUVILLE_GYM_WATTSON);
+            FlagClear(FLAG_WATTSON_REMATCH_AVAILABLE);
+        }
+    }
+
     if(!FlagGet(FLAG_UPDATED_MEGA_STONE_POCKET)){
         for (i = 0; i < BAG_MEGASTONES_COUNT; i++)
         {


### PR DESCRIPTION
If the player saves and reloads after beating Norman but before completing New Mauville Wattson's flags can break which results in him disappearing and New Mauville being uncompletable. This change makes it so that very old saves that have completed New Mauville and talked to Wattson cannot get Mega Lanturn but prevents new saves from being broken by that change.